### PR TITLE
Remove balance_visits basis function from AuxTel spectroscopic survey.

### DIFF
--- a/.ts_pre_commit_config.yaml
+++ b/.ts_pre_commit_config.yaml
@@ -1,0 +1,6 @@
+check-yaml: true
+check-xml: true
+black: true
+flake8: true
+isort: true
+mypy: true

--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -4,6 +4,12 @@
 Version History
 ===============
 
+v0.5.1
+------
+
+* In ``auxtel/basis_functions``, remove balanceVisists from spec survey and update unit test. 
+* Add pre_commit_config file. 
+
 v0.5.0
 ------
 

--- a/python/lsst/ts/fbs/utils/auxtel/basis_functions.py
+++ b/python/lsst/ts/fbs/utils/auxtel/basis_functions.py
@@ -203,7 +203,4 @@ def get_basis_functions_spectroscopic_survey(
         basis_functions.AvoidDirectWind(
             wind_speed_maximum=wind_speed_maximum, nside=nside
         ),
-        basis_functions.BalanceVisits(
-            nobs_reference=nobs_reference, note_survey=note, note_interest=note_interest
-        ),
     ]

--- a/tests/auxtel/test_basis_functions.py
+++ b/tests/auxtel/test_basis_functions.py
@@ -67,4 +67,4 @@ def test_get_basis_functions_spectroscopic_survey() -> None:
         nobs_reference=3,
     )
 
-    assert len(basis_functions) == 11
+    assert len(basis_functions) == 10


### PR DESCRIPTION
Needed to enforce following single targets as requested by spectroscopic team. 