### PR TITLE
OBS-816: Add Sun Altitude limits for surveys

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -4,6 +4,11 @@
 Version History
 ===============
 
+v0.15.1
+-------
+* Added SunAltLimitBasisFunctions to cwfs, imaging and spectroscopic surveys, to ensure that the FBS stops requesting targets beyond twilight time. The default values are -10 deg, -12 deg, and -10 deg respectively. Placing these limits lightens the load on the OSs around enabling and disabling the Scheduler near twilight.
+
+
 v0.15.0
 -------
 

--- a/python/lsst/ts/fbs/utils/auxtel/basis_functions.py
+++ b/python/lsst/ts/fbs/utils/auxtel/basis_functions.py
@@ -44,6 +44,7 @@ def get_basis_functions_image_survey(
     additional_notes: list[tuple[str, int]] | None = None,
     avoid_wind: bool = True,
     include_slew: bool = True,
+    sun_alt_limit: float = -12,
 ) -> typing.List[basis_functions.BaseBasisFunction]:
     """Get the basis functions for the image survey.
 
@@ -82,6 +83,9 @@ def get_basis_functions_image_survey(
         Makes use align with the spectroscopic survey.
     include_slew : `bool`, optional
         Include slewtime basis functions (or not).
+    sun_alt_limit : `float`, optional
+        Sun altitude limit for the survey (degrees).
+        Sun must be below this limit for survey to be feasible.
 
     Returns
     -------
@@ -89,6 +93,7 @@ def get_basis_functions_image_survey(
     """
 
     bfs = [
+        basis_functions.SunAltLimitBasisFunction(alt_limit=sun_alt_limit),
         basis_functions.MoonAvoidanceBasisFunction(nside=nside),
         basis_functions.AltAzShadowMaskBasisFunction(
             min_alt=26.0, max_alt=85.0, nside=nside, shadow_minutes=0.0, pad=0.0
@@ -157,6 +162,7 @@ def get_basis_functions_cwfs_survey(
     note: str,
     time_gap_min: float,
     wind_speed_maximum: float,
+    sun_alt_limit: float = -10,
 ) -> typing.List[basis_functions.BaseBasisFunction]:
     """Get the basis functions for the CWFS survey.
 
@@ -174,6 +180,9 @@ def get_basis_functions_cwfs_survey(
     wind_speed_maximum : `float`
         Maximum wind speed tolerated for the observations of the survey,
         in m/s.
+    sun_alt_limit : `float`, optional
+        Sun altitude limit for the survey (degrees).
+        Sun must be below this limit for survey to be feasible.
 
     Returns
     -------
@@ -193,6 +202,7 @@ def get_basis_functions_cwfs_survey(
         basis_functions.AvoidDirectWind(
             wind_speed_maximum=wind_speed_maximum, nside=nside
         ),
+        basis_functions.SunAltLimitBasisFunction(alt_limit=sun_alt_limit),
     ]
 
 
@@ -208,6 +218,7 @@ def get_basis_functions_spectroscopic_survey(
     nobs_reference: int,
     note_interest: str,
     include_slew: bool = True,
+    sun_alt_limit: float = -10,
 ) -> typing.List[basis_functions.BaseBasisFunction]:
     """Get basis functions for spectroscopic survey.
 
@@ -236,6 +247,9 @@ def get_basis_functions_spectroscopic_survey(
         reference number of observations.
     include_slew : `bool`, optional
         Include slewtime basis functions (or not).
+    sun_alt_limit : `float`, optional
+        Sun altitude limit for the survey (degrees).
+        Sun must be below this limit for survey to be feasible.
 
     Returns
     -------
@@ -244,6 +258,7 @@ def get_basis_functions_spectroscopic_survey(
     """
 
     bfs = [
+        basis_functions.SunAltLimitBasisFunction(alt_limit=sun_alt_limit),
         basis_functions.MoonAvoidanceBasisFunction(
             nside=nside, moon_distance=moon_distance
         ),

--- a/python/lsst/ts/fbs/utils/auxtel/surveys.py
+++ b/python/lsst/ts/fbs/utils/auxtel/surveys.py
@@ -146,6 +146,7 @@ def generate_image_survey_from_target(
     survey_detailers: typing.List[BaseDetailer],
     avoid_wind: bool = True,
     include_slew: bool = True,
+    sun_alt_limit: float = -12,
 ) -> BaseSurvey:
     """Generate image survey, for single Target with dithers
 
@@ -165,6 +166,9 @@ def generate_image_survey_from_target(
         Makes use align with the spectroscopic survey.
     include_slew : `bool`, optional
         If True, include slewtime basis functions.
+    sun_alt_limit : `float`, optional
+        Sun altitude limit for the survey (degrees).
+        Sun must be below this limit for survey to be feasible.
 
     Returns
     -------
@@ -185,6 +189,7 @@ def generate_image_survey_from_target(
         gap_min=target.visit_gap,
         additional_notes=None,
         include_slew=include_slew,
+        sun_alt_limit=sun_alt_limit,
     )
 
     # Set up a sequence of nexp exposures per filter
@@ -242,6 +247,7 @@ def generate_cwfs_survey(
     cwfs_block_name : `str`
         Name of the cwfs block survey.
 
+
     Returns
     -------
     `GreedySurvey`
@@ -272,6 +278,7 @@ def generate_spectroscopic_survey(
     nfields: int,
     survey_detailers: typing.List[BaseDetailer],
     include_slew: bool = True,
+    sun_alt_limit: float = -10,
 ) -> BaseSurvey:
     """Generate Spectroscopic Survey.
 
@@ -289,6 +296,9 @@ def generate_spectroscopic_survey(
         List of survey detailers.
     include_slew : `bool`, optional
         If True, include slewtime basis functions.
+    sun_alt_limit : `float`, optional
+        Sun altitude limit for the survey (degrees).
+        Sun must be below this limit for survey to be feasible.
 
     Returns
     -------
@@ -307,6 +317,7 @@ def generate_spectroscopic_survey(
         moon_distance=target.moon_distance,
         nobs_reference=nfields,
         include_slew=include_slew,
+        sun_alt_limit=sun_alt_limit,
     )
 
     observation = ObservationArray(n=target.nexp)

--- a/tests/auxtel/test_basis_functions.py
+++ b/tests/auxtel/test_basis_functions.py
@@ -42,7 +42,7 @@ def test_get_basis_functions_image_survey() -> None:
         include_slew=True,
     )
 
-    assert len(basis_functions) == 11
+    assert len(basis_functions) == 12
 
 
 def test_get_basis_functions_cwfs_survey() -> None:
@@ -53,7 +53,7 @@ def test_get_basis_functions_cwfs_survey() -> None:
         wind_speed_maximum=7.0,
     )
 
-    assert len(basis_functions) == 8
+    assert len(basis_functions) == 9
 
 
 def test_get_basis_functions_spectroscopic_survey() -> None:
@@ -70,7 +70,7 @@ def test_get_basis_functions_spectroscopic_survey() -> None:
         nobs_reference=3,
     )
 
-    assert len(basis_functions) == 8
+    assert len(basis_functions) == 9
 
 
 def test_get_basis_functions_spectroscopic_survey_no_wind() -> None:
@@ -87,4 +87,4 @@ def test_get_basis_functions_spectroscopic_survey_no_wind() -> None:
         nobs_reference=3,
     )
 
-    assert len(basis_functions) == 7
+    assert len(basis_functions) == 8


### PR DESCRIPTION
I added a sun altitude limit for spectroscopy, cwfs and imaging surveys. 
The defaults for spectroscopy and cwfs are set at -10 degrees; imaging is set to -12. 

