### PR TITLE
SP-2357: Let templates run even with wrong 'night'; avoid twi_blob error

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -4,6 +4,14 @@
 Version History
 ===============
 
+v0.17.1
+-------
+* Fix some issues with the SV configuration: observation_reason needs underscores and no spaces, and n_obs template should not be 0 for surveys that use rubin_scheduler <= 3.10.0 if they also use the NObsPerYear basis function.
+
+v0.17.0
+-------
+* Add SV survey configuration support - generation of the footprint, as well as the various tiers of surveys (DDF, long-gaps (triplets), template gathering, standard pairs, twilight pairs, greedy (single) visits, and a final layer of early template gathering). This includes a DDF prescheduling generation file that more likely will long-term live in rubin_scheduler but is currently divergent from the version we have there (on purpose, to suppose "ocean" ddfs).
+
 v0.16.1
 -------
 

--- a/python/lsst/ts/fbs/utils/maintel/__init__.py
+++ b/python/lsst/ts/fbs/utils/maintel/__init__.py
@@ -26,4 +26,3 @@ from .surveys import *
 from .sv_config import *
 from .sv_surveys import *
 from .ddf_presched import *
-

--- a/python/lsst/ts/fbs/utils/maintel/ddf_presched.py
+++ b/python/lsst/ts/fbs/utils/maintel/ddf_presched.py
@@ -607,7 +607,7 @@ def generate_ddf_scheduled_obs(
                     obs["scheduler_note"] = "DD:%s" % ddf_name
                     obs["target_name"] = "DDF %s" % ddf_name
                     obs["science_program"] = science_program
-                    obs["observation_reason"] = "DDF %s" % ddf_name
+                    obs["observation_reason"] = "DDF_%s" % ddf_name
                     obs["mjd_tol"] = mjd_tol
                     obs["dist_tol"] = dist_tol
                     # Need to set something for HA limits
@@ -631,7 +631,7 @@ def generate_ddf_scheduled_obs(
                     obs["scheduler_note"] = "DD:%s" % ddf_name.replace("_a", "_b")
                     obs["target_name"] = "DDF %s" % ddf_name.replace("_a", "_b")
                     obs["science_program"] = science_program
-                    obs["observation_reason"] = "DDF %s" % ddf_name.replace("_a", "_b")
+                    obs["observation_reason"] = "DDF_%s" % ddf_name.replace("_a", "_b")
 
                     obs["mjd_tol"] = mjd_tol
                     obs["dist_tol"] = dist_tol
@@ -656,7 +656,7 @@ def generate_ddf_scheduled_obs(
                     obs["scheduler_note"] = "DD:%s" % ddf_name
                     obs["target_name"] = "DDF %s" % ddf_name
                     obs["science_program"] = science_program
-                    obs["observation_reason"] = "DDF %s" % ddf_name
+                    obs["observation_reason"] = "DDF_%s" % ddf_name
 
                     obs["mjd_tol"] = mjd_tol
                     obs["dist_tol"] = dist_tol

--- a/python/lsst/ts/fbs/utils/maintel/sv_surveys.py
+++ b/python/lsst/ts/fbs/utils/maintel/sv_surveys.py
@@ -1617,7 +1617,7 @@ def generate_twi_blobs(
         observation_reason = f"pairs_{bandname}"
         if bandname2 is not None:
             observation_reason += f"{bandname2}"
-        observation_reason = +f"_{pair_time :.1f}"
+        observation_reason += f"_{pair_time :.1f}"
 
         surveys.append(
             BlobSurvey(

--- a/python/lsst/ts/fbs/utils/maintel/sv_surveys.py
+++ b/python/lsst/ts/fbs/utils/maintel/sv_surveys.py
@@ -1391,7 +1391,7 @@ def generate_blobs(
         observation_reason = f"pairs_{bandname}"
         if bandname2 is not None:
             observation_reason += f"{bandname2}"
-        observation_reason = +f"_{pair_time :.1f}"
+        observation_reason += f"_{pair_time :.1f}"
 
         surveys.append(
             BlobSurvey(

--- a/tests/maintel/test_sv_surveys.py
+++ b/tests/maintel/test_sv_surveys.py
@@ -73,10 +73,6 @@ class Test_SV_Surveys(unittest.TestCase):
         )
         assert len(surveys) > 0
 
-    def test_generate_blobs(self) -> None:
-        surveys = sv_surveys.generate_blobs(footprints=self.survey_info["Footprints"])
-        assert len(surveys) > 0
-
     def test_gen_ddf_surveys(self) -> None:
         surveys = sv_surveys.gen_ddf_surveys(
             ddf_config_file=os.path.join(get_data_dir(), "ddf_sv.dat")


### PR DESCRIPTION
Conditions.night is much larger than we expect (expected 2, got 2089) so this removes the "only in year 1" constraint to let template surveys run whenever.

Removes a mistake on nobs for the template gathering in the twilight blob that caused y band to have a problem calculating reward.

Updates observation-reason where possible to use underscores not spaces. 