### PR TITLE
Make all pairs surveys use a minimum area (area_required)

### DIFF
--- a/doc/version_history.rst
+++ b/doc/version_history.rst
@@ -4,6 +4,10 @@
 Version History
 ===============
 
+v0.17.6
+-------
+* Add minimum viable area for all kinds of pairs surveys, to avoid triggering these when there is not enough area to get a useful pairs (useful in terms of a minimum time separation, but also to avoid many filter changes).
+
 v0.17.5
 -------
 * Reduce primary SV survey area from approximately 3000 sq degrees to about 750, in response to concerns about remaining time available during commissioning and current image quality, plus ability to make and use templates.

--- a/python/lsst/ts/fbs/utils/maintel/sv_surveys.py
+++ b/python/lsst/ts/fbs/utils/maintel/sv_surveys.py
@@ -628,13 +628,13 @@ def gen_template_surveys(
                 bandname2=None,
                 exptime=exptime,
                 ideal_pair_time=pair_time,
+                area_required=area_required,
                 survey_name=survey_name,
                 science_program=science_program,
                 observation_reason=f"template_blob_{bandname}_{pair_time :.1f}",
                 ignore_obs=ignore_obs,
                 nexp=nexp,
                 detailers=detailer_list,
-                area_required=area_required,
                 **blob_survey_params,
             )
         )
@@ -655,6 +655,7 @@ def blob_for_long(
     u_nexp: int = U_NEXP,
     n_obs_template: dict = None,
     pair_time: float = 33.0,
+    area_required: float = 150.0,
     season: float = 365.25,
     season_start_hour: float = -4.0,
     season_end_hour: float = 2.0,
@@ -710,6 +711,8 @@ def blob_for_long(
         If None, sets to 3 each. Default None.
     pair_time : `float`
         The ideal time between pairs (minutes). Default 33.
+    area_required : `float`
+        The minimum required current available area for the survey, sq deg.
     season : float
         The length of season (i.e., how long before templates expire) (days)
     season_start_hour : `float`
@@ -873,6 +876,7 @@ def blob_for_long(
                 bandname2=bandname2,
                 exptime=exptime,
                 ideal_pair_time=pair_time,
+                area_required=area_required,
                 survey_name=survey_name,
                 ignore_obs=ignore_obs,
                 nexp=nexp,
@@ -895,6 +899,7 @@ def gen_long_gaps_survey(
     u_exptime: float = U_EXPTIME,
     u_nexp: int = U_NEXP,
     pair_time: float = 33.0,
+    area_required: float = 150.0,
     night_pattern: list[bool] = [True, True],
     gap_range: list[float] = [2, 7],
     HA_min: float = 12,
@@ -927,6 +932,8 @@ def gen_long_gaps_survey(
         The number of exposures per visit for u band visits.
     pair_time : `float`
         The ideal time between pairs (minutes). Default 33.
+    area_required : `float`
+        The minimum required current available area for the survey, sq deg.
     night_pattern : `list` [ `bool` ]
         Which nights to let the survey execute.
         Default of [True, True] executes every night.
@@ -976,6 +983,7 @@ def gen_long_gaps_survey(
             u_exptime=u_exptime,
             u_nexp=u_nexp,
             pair_time=pair_time,
+            area_required=area_required,
             nside=nside,
             band1s=[bandname1],
             band2s=[bandname2],
@@ -1157,6 +1165,7 @@ def generate_blobs(
     u_nexp: int = U_NEXP,
     n_obs_template: dict = None,
     pair_time: float = 33.0,
+    area_required: float = 150.0,
     season: float = 365.25,
     season_start_hour: float = -4.0,
     season_end_hour: float = 2.0,
@@ -1206,6 +1215,8 @@ def generate_blobs(
         If None, sets to 3 each. Default None.
     pair_time : `float`
         The ideal time between pairs (minutes). Default 33.
+    area_required : `float`
+        The minimum required current available area for the survey, sq deg.
     season : float
         The length of season (i.e., how long before templates expire) (days)
     season_start_hour : `float`
@@ -1416,6 +1427,7 @@ def generate_blobs(
                 bandname2=bandname2,
                 exptime=exptime,
                 ideal_pair_time=pair_time,
+                area_required=area_required,
                 survey_name=survey_name,
                 science_program=science_program,
                 observation_reason=observation_reason,
@@ -1440,6 +1452,7 @@ def generate_twi_blobs(
     nexp: int = NEXP,
     n_obs_template: dict = None,
     pair_time: float = 15.0,
+    area_required: float = 50.0,
     season: float = 365.25,
     season_start_hour: float = -4.0,
     season_end_hour: float = 2.0,
@@ -1482,6 +1495,8 @@ def generate_twi_blobs(
         If None, sets to 3 each. Default None.
     pair_time : `float`
         The ideal time between pairs (minutes). Default 33.
+    area_required : `float`
+        The minimum required current available area for the survey, sq deg.
     season : float
         The length of season (i.e., how long before templates expire) (days)
     season_start_hour : `float`
@@ -1642,6 +1657,7 @@ def generate_twi_blobs(
                 bandname2=bandname2,
                 exptime=exptime,
                 ideal_pair_time=pair_time,
+                area_required=area_required,
                 survey_name=survey_name,
                 science_program=science_program,
                 observation_reason=observation_reason,


### PR DESCRIPTION
The pairs surveys are programmed in split filters, so when they trigger with only a small amount of area to observe, this results in rapid filter changes. 
This PR adds minimum areas before those surveys will trigger - the area is different for pairs surveys expecting different amounts of time for execution (this does interplay a bit with the masks and shadow_minutes, which is part of the reason for the differences). 